### PR TITLE
Add CPU/GPU device flexibility with automatic CUDA detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ $DATA_DIR/pyavi/$REFERENCE/video_out.avi - output video (as shown below)
   <img src="img/ex2.jpg" width="45%"/>
 </p>
 
+## Device Support
+
+This implementation supports both **CUDA GPU** and **CPU** execution:
+
+- **CUDA GPU**: Automatically detected and used if available for faster processing
+- **CPU**: Used as fallback when CUDA is not available, or can be forced for compatibility
+
+### Device Selection
+The code automatically detects and uses the best available device:
+- If CUDA is available → Uses GPU for acceleration
+- If CUDA is not available → Falls back to CPU
+
+### CPU-Only Execution
+To force CPU-only execution (e.g., for compatibility or debugging), you can set:
+```python
+import os
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
+```
+
+Or modify the device selection in the scripts directly.
+
 ## Publications
  
 ```

--- a/SyncNetInstance.py
+++ b/SyncNetInstance.py
@@ -34,10 +34,11 @@ def calc_pdist(feat1, feat2, vshift=10):
 
 class SyncNetInstance(torch.nn.Module):
 
-    def __init__(self, dropout = 0, num_layers_in_fc_layers = 1024):
+    def __init__(self, dropout = 0, num_layers_in_fc_layers = 1024, device='cpu'):
         super(SyncNetInstance, self).__init__();
 
-        self.__S__ = S(num_layers_in_fc_layers = num_layers_in_fc_layers).cuda();
+        self.device = device
+        self.__S__ = S(num_layers_in_fc_layers = num_layers_in_fc_layers).to(self.device);
 
     def evaluate(self, opt, videofile):
 
@@ -75,7 +76,7 @@ class SyncNetInstance(torch.nn.Module):
         im = numpy.transpose(im,(0,3,4,1,2))
 
         imtv = torch.autograd.Variable(torch.from_numpy(im.astype(float)).float())
-
+        
         # ========== ==========
         # Load audio
         # ========== ==========
@@ -109,12 +110,12 @@ class SyncNetInstance(torch.nn.Module):
             
             im_batch = [ imtv[:,:,vframe:vframe+5,:,:] for vframe in range(i,min(lastframe,i+opt.batch_size)) ]
             im_in = torch.cat(im_batch,0)
-            im_out  = self.__S__.forward_lip(im_in.cuda());
+            im_out  = self.__S__.forward_lip(im_in.to(self.device));
             im_feat.append(im_out.data.cpu())
 
             cc_batch = [ cct[:,:,:,vframe*4:vframe*4+20] for vframe in range(i,min(lastframe,i+opt.batch_size)) ]
             cc_in = torch.cat(cc_batch,0)
-            cc_out  = self.__S__.forward_aud(cc_in.cuda())
+            cc_out  = self.__S__.forward_aud(cc_in.to(self.device))
             cc_feat.append(cc_out.data.cpu())
 
         im_feat = torch.cat(im_feat,0)
@@ -184,7 +185,7 @@ class SyncNetInstance(torch.nn.Module):
             
             im_batch = [ imtv[:,:,vframe:vframe+5,:,:] for vframe in range(i,min(lastframe,i+opt.batch_size)) ]
             im_in = torch.cat(im_batch,0)
-            im_out  = self.__S__.forward_lipfeat(im_in.cuda());
+            im_out  = self.__S__.forward_lipfeat(im_in.to(self.device));
             im_feat.append(im_out.data.cpu())
 
         im_feat = torch.cat(im_feat,0)

--- a/demo_feature.py
+++ b/demo_feature.py
@@ -2,6 +2,7 @@
 #-*- coding: utf-8 -*-
 
 import time, pdb, argparse, subprocess
+import torch
 
 from SyncNetInstance import *
 
@@ -22,7 +23,11 @@ opt = parser.parse_args();
 
 # ==================== RUN EVALUATION ====================
 
-s = SyncNetInstance();
+# Check if CUDA is available, otherwise use CPU
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+print(f'[INFO] Using device: {device}')
+
+s = SyncNetInstance(device=device);
 
 s.loadParameters(opt.initial_model);
 print("Model %s loaded."%opt.initial_model);

--- a/demo_syncnet.py
+++ b/demo_syncnet.py
@@ -2,6 +2,7 @@
 #-*- coding: utf-8 -*-
 
 import time, pdb, argparse, subprocess
+import torch
 
 from SyncNetInstance import *
 
@@ -22,7 +23,11 @@ opt = parser.parse_args();
 
 # ==================== RUN EVALUATION ====================
 
-s = SyncNetInstance();
+# Check if CUDA is available, otherwise use CPU
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+print(f'[INFO] Using device: {device}')
+
+s = SyncNetInstance(device=device);
 
 s.loadParameters(opt.initial_model);
 print("Model %s loaded."%opt.initial_model);

--- a/detectors/s3fd/__init__.py
+++ b/detectors/s3fd/__init__.py
@@ -12,7 +12,7 @@ img_mean = np.array([104., 117., 123.])[:, np.newaxis, np.newaxis].astype('float
 
 class S3FD():
 
-    def __init__(self, device='cuda'):
+    def __init__(self, device='cpu'):
 
         tstamp = time.time()
         self.device = device

--- a/detectors/s3fd/box_utils.py
+++ b/detectors/s3fd/box_utils.py
@@ -35,7 +35,7 @@ def nms_(dets, thresh):
         inds = np.where(ovr <= thresh)[0]
         order = order[inds + 1]
 
-    return np.array(keep).astype(np.int)
+    return np.array(keep).astype(int)
 
 
 def decode(loc, priors, variances):

--- a/device_utils.py
+++ b/device_utils.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+#-*- coding: utf-8 -*-
+
+import torch
+
+def get_device(prefer_cuda=True):
+    """
+    Get the best available device (CUDA if available and preferred, otherwise CPU)
+    
+    Args:
+        prefer_cuda (bool): Whether to prefer CUDA over CPU if available
+        
+    Returns:
+        str: Device string ('cuda' or 'cpu')
+    """
+    if prefer_cuda and torch.cuda.is_available():
+        device = 'cuda'
+        print(f'[INFO] Using CUDA GPU: {torch.cuda.get_device_name(0)}')
+    else:
+        device = 'cpu'
+        if prefer_cuda and not torch.cuda.is_available():
+            print('[INFO] CUDA not available, falling back to CPU')
+        else:
+            print('[INFO] Using CPU')
+    
+    return device
+
+def print_device_info():
+    """Print information about available devices"""
+    print("=" * 50)
+    print("Device Information:")
+    print(f"CUDA Available: {torch.cuda.is_available()}")
+    
+    if torch.cuda.is_available():
+        print(f"CUDA Version: {torch.version.cuda}")
+        print(f"GPU Count: {torch.cuda.device_count()}")
+        for i in range(torch.cuda.device_count()):
+            print(f"GPU {i}: {torch.cuda.get_device_name(i)}")
+    
+    print(f"PyTorch Version: {torch.__version__}")
+    print("=" * 50)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,6 +2,7 @@
 
 import sys, time, os, pdb, argparse, pickle, subprocess, glob, cv2
 import numpy as np
+import torch
 from shutil import rmtree
 
 import scenedetect
@@ -184,7 +185,11 @@ def crop_video(opt,track,cropfile):
 
 def inference_video(opt):
 
-  DET = S3FD(device='cuda')
+  # Check if CUDA is available, otherwise use CPU
+  device = 'cuda' if torch.cuda.is_available() else 'cpu'
+  print(f'[INFO] Using device: {device}')
+  
+  DET = S3FD(device=device)
 
   flist = glob.glob(os.path.join(opt.frames_dir,opt.reference,'*.jpg'))
   flist.sort()

--- a/run_syncnet.py
+++ b/run_syncnet.py
@@ -2,6 +2,7 @@
 #-*- coding: utf-8 -*-
 
 import time, pdb, argparse, subprocess, pickle, os, gzip, glob
+import torch
 
 from SyncNetInstance import *
 
@@ -24,7 +25,11 @@ setattr(opt,'crop_dir',os.path.join(opt.data_dir,'pycrop'))
 
 # ==================== LOAD MODEL AND FILE LIST ====================
 
-s = SyncNetInstance();
+# Check if CUDA is available, otherwise use CPU
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+print(f'[INFO] Using device: {device}')
+
+s = SyncNetInstance(device=device);
 
 s.loadParameters(opt.initial_model);
 print("Model %s loaded."%opt.initial_model);


### PR DESCRIPTION
Replace hardcoded .cuda() calls with .to(self.device) and add automatic device detection so SyncNet runs on systems without a CUDA-capable GPU.

Changes:
- SyncNetInstance: add device parameter (default 'cpu'), store as self.device, move model and all input tensors with .to(self.device)
- run_syncnet.py, run_pipeline.py, demo_syncnet.py, demo_feature.py: detect CUDA availability at startup and pass device to SyncNetInstance
- detectors/s3fd/__init__.py: change default device from 'cuda' to 'cpu' so the detector also falls back gracefully on CPU-only machines
- detectors/s3fd/box_utils.py: replace deprecated np.int with int (required for NumPy >= 1.20, affects CPU execution)
- device_utils.py: add helper utilities for device selection
- README.md: document automatic device selection and CPU-only usage

Backward compatibility is preserved: existing CUDA setups continue to work, and the batch_size and other defaults are unchanged.